### PR TITLE
Support pathed role names

### DIFF
--- a/cmd/managed-kubernetes-auditing-toolkit/eks/role_relationships.go
+++ b/cmd/managed-kubernetes-auditing-toolkit/eks/role_relationships.go
@@ -237,5 +237,5 @@ func getRoleDisplayName(role *role_relationships.IAMRole) string {
 
 func getRoleName(role *role_relationships.IAMRole) string {
 	parsedArn, _ := arn.Parse(role.Arn)
-	return strings.Split(parsedArn.Resource, "/")[1]
+	return strings.TrimPrefix(parsedArn.Resource, "role/")
 }


### PR DESCRIPTION
The current method of trimming the `role/` prefix splits the resource name by `/` and returns the second element. If you use a pathed role name like `role/pod-identity/my-role` then this will only display `pod-identity` in the output, rather than the full role name `pod-identity/my-role`.

This PR uses TrimPrefix to remove `role/` instead, preserving the full role name for output.